### PR TITLE
Fix exports for bundle

### DIFF
--- a/src/PscIde.js
+++ b/src/PscIde.js
@@ -1,8 +1,8 @@
-//module PscIde
+// module PscIde
 
 var net = require('net');
 
-module.exports.send = function(cmd){
+exports.send = function(cmd){
   return function(port){
     return function(cb){
       return function(err){


### PR DESCRIPTION
Apparently `psc-bundle` doesn't notice `module.exports`, silently disappears and things break...
