### PR TITLE
psc 0.9 updates

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,8 +18,8 @@
     "purescript-maybe": "^1.0.0",
     "purescript-aff": "^1.0.0",
     "purescript-node-fs": "^1.0.0",
-    "purescript-node-child-process": "purescript-node/purescript-node-child-process#1.0-updates",
-    "purescript-parallel": "~1.0.0"
+    "purescript-node-child-process": "^1.0.0",
+    "purescript-parallel": "^1.0.0"
   },
   "repository": {
     "type": "git",

--- a/bower.json
+++ b/bower.json
@@ -12,13 +12,13 @@
     "output"
   ],
   "dependencies": {
-    "purescript-console": "^0.1.0",
-    "purescript-argonaut": "~0.12.0",
-    "purescript-arrays": "~0.4.4",
-    "purescript-maybe": "~0.3.5",
-    "purescript-aff": "~0.16.0",
-    "purescript-node-fs": "^0.11.0",
-    "purescript-node-child-process": "^0.6.1"
+    "purescript-console": "^1.0.0",
+    "purescript-argonaut": "^1.0.0",
+    "purescript-arrays": "^1.0.0",
+    "purescript-maybe": "^1.0.0",
+    "purescript-aff": "~0.17.0",
+    "purescript-node-fs": "^1.0.0",
+    "purescript-node-child-process": "purescript-node/purescript-node-child-process#1.0-updates"
   },
   "repository": {
     "type": "git",

--- a/bower.json
+++ b/bower.json
@@ -16,9 +16,10 @@
     "purescript-argonaut": "^1.0.0",
     "purescript-arrays": "^1.0.0",
     "purescript-maybe": "^1.0.0",
-    "purescript-aff": "~0.17.0",
+    "purescript-aff": "^1.0.0",
     "purescript-node-fs": "^1.0.0",
-    "purescript-node-child-process": "purescript-node/purescript-node-child-process#1.0-updates"
+    "purescript-node-child-process": "purescript-node/purescript-node-child-process#1.0-updates",
+    "purescript-parallel": "~1.0.0"
   },
   "repository": {
     "type": "git",

--- a/src/PscIde/Command.purs
+++ b/src/PscIde/Command.purs
@@ -2,10 +2,9 @@ module PscIde.Command where
 
 import Prelude
 import Control.Alt ((<|>))
-import Data.Argonaut.Combinators ((~>), (:=), (.?))
 import Data.Argonaut.Core (jsonEmptyObject, jsonSingletonObject, Json, toString)
-import Data.Argonaut.Decode (class DecodeJson, decodeJson)
-import Data.Argonaut.Encode (class EncodeJson, encodeJson)
+import Data.Argonaut.Decode (class DecodeJson, decodeJson, (.?))
+import Data.Argonaut.Encode (class EncodeJson, encodeJson, (~>), (:=))
 import Data.Argonaut.Parser (jsonParser)
 import Data.Array (singleton)
 import Data.Either (either, Either(..))

--- a/src/PscIde/Server.purs
+++ b/src/PscIde/Server.purs
@@ -15,7 +15,9 @@ import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Aff.Par (Par(Par), runPar)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Console (CONSOLE)
-import Node.ChildProcess (CHILD_PROCESS, ChildProcess, Exit(Normally), onClose, onError, defaultSpawnOptions, spawn, defaultExecOptions, execFile)
+import Node.ChildProcess (CHILD_PROCESS, ChildProcess, StdIOBehaviour,
+                         Exit(Normally), onClose, onError, defaultSpawnOptions,
+                         spawn, defaultExecOptions, execFile, pipe)
 import PscIde (NET, quit)
 
 data ServerStartResult =
@@ -23,11 +25,15 @@ data ServerStartResult =
   | Closed
   | StartError String
 
--- | Start a psc-ide server instance
 startServer ∷ forall eff. String → Int → Maybe String
   → Aff (cp ∷ CHILD_PROCESS, console ∷ CONSOLE, avar ∷ AVAR | eff) ServerStartResult
-startServer exe port projectRoot = do
-    cp <- liftEff (spawn exe ["-p", show port] defaultSpawnOptions { cwd = projectRoot })
+startServer = startServer' pipe
+
+-- | Start a psc-ide server instance
+startServer' ∷ forall eff. Array (Maybe StdIOBehaviour) → String → Int → Maybe String
+  → Aff (cp ∷ CHILD_PROCESS, console ∷ CONSOLE, avar ∷ AVAR | eff) ServerStartResult
+startServer' stdio exe port projectRoot = do
+    cp <- liftEff (spawn exe ["-p", show port] defaultSpawnOptions { cwd = projectRoot, stdio = stdio })
     let handleErr = makeAff \_ succ -> do
                       onError cp (\_ -> succ $ StartError "psc-ide-server error")
                       onClose cp (\exit -> case exit of

--- a/src/PscIde/Server.purs
+++ b/src/PscIde/Server.purs
@@ -12,9 +12,9 @@ import Node.Which (which)
 import Control.Alt ((<|>))
 import Control.Monad.Aff (attempt, Aff, later', makeAff)
 import Control.Monad.Aff.AVar (AVAR)
-import Control.Monad.Aff.Par (Par(Par), runPar)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Console (CONSOLE)
+import Control.Parallel.Class (parallel, runParallel)
 import Node.ChildProcess (CHILD_PROCESS, ChildProcess, StdIOBehaviour,
                          Exit(Normally), onClose, onError, defaultSpawnOptions,
                          spawn, defaultExecOptions, execFile, pipe)
@@ -41,7 +41,7 @@ startServer' stdio exe port projectRoot = do
                                      (Normally n) -> succ $ StartError $ "Error code returned: "<> show n
                                      _ -> succ $ StartError "Other close error")
 
-    runPar (Par handleErr <|> Par (later' 100 $ pure $ Started cp))
+    runParallel (parallel handleErr <|> parallel (later' 100 $ pure $ Started cp))
 
 -- | Stop a psc-ide server.
 stopServer :: forall eff. Int -> Aff (cp :: CHILD_PROCESS, net :: NET | eff) Unit

--- a/src/PscIde/Server.purs
+++ b/src/PscIde/Server.purs
@@ -24,7 +24,7 @@ data ServerStartResult =
   | StartError String
 
 -- | Start a psc-ide server instance
-startServer ∷ forall eff. String → Int -> Maybe String
+startServer ∷ forall eff. String → Int → Maybe String
   → Aff (cp ∷ CHILD_PROCESS, console ∷ CONSOLE, avar ∷ AVAR | eff) ServerStartResult
 startServer exe port projectRoot = do
     cp <- liftEff (spawn exe ["-p", show port] defaultSpawnOptions { cwd = projectRoot })
@@ -32,7 +32,7 @@ startServer exe port projectRoot = do
                       onError cp (\_ -> succ $ StartError "psc-ide-server error")
                       onClose cp (\exit -> case exit of
                                      (Normally 0) -> succ Closed
-                                     (Normally n) -> succ $ StartError $ "Error code returned: "++ show n
+                                     (Normally n) -> succ $ StartError $ "Error code returned: "<> show n
                                      _ -> succ $ StartError "Other close error")
 
     runPar (Par handleErr <|> Par (later' 100 $ pure $ Started cp))


### PR DESCRIPTION
Still waiting for `ps-node-child-process` to be updated.

This also adds `startServer'` which can be used if you want custom stdio behavior. Previously the behavior was to pipe everything to the child_process instance and if you don't read anything from stdout the server will block writing when the buffer is full. This then would make the server unable to process any commands. This happens when the server is running and you build a big project and the server outputs a lot of "Reloaded file" lines.

The `StdIOBehavior` signature is such that I wasn't able to pass in `stderr` without `unsafeCoerce` in the calling code, so I'm not sure I'm doing the right thing here. @hdgarrood is there a reason why `ps-node-child-process` doesn't itself use `stderr` and `stdout` from Node.Process for `process.*` variables?
