### PR TITLE
[WIP] Functions for starting multiple psc-ide servers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,8 @@
     "purescript-aff": "^1.0.0",
     "purescript-node-fs": "^1.0.0",
     "purescript-node-child-process": "^1.0.0",
-    "purescript-parallel": "^1.0.0"
+    "purescript-parallel": "^1.0.0",
+    "purescript-random": "^1.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
@kRITZCREEK thoughts, particularly on the general scheme of things? Additions here are an a-la-carte approach, rather than one new `startServer` overload.

I'm about to push a branch of pscid that shows this, have start-multiple-servers branch of atom plugin.

Need to rebase this to 0.9 changes, but branches of pscid/atom are still on 0.8.5.
