### PR TITLE
Skip past bower_components to find project

### DIFF
--- a/src/PscIde/Project.purs
+++ b/src/PscIde/Project.purs
@@ -1,6 +1,7 @@
 module PscIde.Project where
 
 import Prelude
+import Data.String (contains)
 import Node.Path as NP
 import Control.Monad.Eff (Eff)
 import Data.Maybe (Maybe(..))
@@ -14,6 +15,8 @@ getRoot path =
       bower = NP.concat [path, "bower.json"] in
   if path == "" || path == parent then
     pure Nothing
+  else if contains "bower_components" path then
+    getRoot parent
   else do
     hasBower <- FS.exists bower
     if hasBower then pure $ Just path else getRoot parent


### PR DESCRIPTION
Refining my notion of "what does a PureScript project look like".

I guess technically a folder could be called `not_bower_components` or just have that name without being such a thing...
