### PR TITLE
Purs ide info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install:
   - chmod a+x $HOME/purescript
   - npm install -g psc-package pulp
 script:
-  - psc-package update && pulp --psc-package build
+  - psc-package install && pulp --psc-package build


### PR DESCRIPTION
Adds `errorLink` and `suggestion` as well as `pursIde` fields, and changes the position types used by build errors to include the full error span