### PR TITLE
Add declarationType to `TypeInfo`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .psc-package/
 yarn.lock
 .psc-ide-port
+/.spago/

--- a/src/PscIde/Command.purs
+++ b/src/PscIde/Command.purs
@@ -119,11 +119,11 @@ declarationTypeFromString :: String -> Maybe DeclarationType
 declarationTypeFromString = case _ of 
   "value" -> Just DeclValue
   "type" -> Just DeclType
-  "typeSynonym" -> Just DeclTypeSynonym
-  "dataConstructor" -> Just DeclDataConstructor
-  "typeClass" -> Just DeclTypeClass
-  "valueOperator" -> Just DeclValueOperator
-  "typeOperator" -> Just DeclTypeOperator
+  "synonym" -> Just DeclTypeSynonym
+  "dataconstructor" -> Just DeclDataConstructor
+  "typeclass" -> Just DeclTypeClass
+  "valueoperator" -> Just DeclValueOperator
+  "typeoperator" -> Just DeclTypeOperator
   "module" -> Just DeclModule
   _ -> Nothing
 
@@ -131,11 +131,11 @@ declarationTypeToString :: DeclarationType -> String
 declarationTypeToString = case _ of 
   DeclValue -> "value" 
   DeclType -> "type" 
-  DeclTypeSynonym -> "typeSynonym" 
-  DeclDataConstructor -> "dataConstructor" 
-  DeclTypeClass -> "typeClass" 
-  DeclValueOperator -> "valueOperator" 
-  DeclTypeOperator -> "typeOperator" 
+  DeclTypeSynonym -> "synonym" 
+  DeclDataConstructor -> "dataconstructor" 
+  DeclTypeClass -> "typeclass" 
+  DeclValueOperator -> "valueoperator" 
+  DeclTypeOperator -> "typeoperator" 
   DeclModule -> "module" 
 
 commandWrapper :: forall a. (EncodeJson a) => String -> a -> Json

--- a/src/PscIde/Command.purs
+++ b/src/PscIde/Command.purs
@@ -47,7 +47,7 @@ data Filter =
   | ModuleFilter (Array String)
   | DependencyFilter (Array String)
   | NamespaceFilter (Array Namespace)
-  | DeclarationFilter (Array String)
+  | DeclarationFilter (Array DeclarationType)
 
 filterWrapper :: forall a. (EncodeJson a) => String -> a -> Json
 filterWrapper f q =
@@ -70,7 +70,7 @@ instance encodeFilter :: EncodeJson Filter where
   encodeJson (NamespaceFilter nss) =
     filterWrapper "namespace" (jsonSingletonObject' "namespaces" nss)
   encodeJson (DeclarationFilter decls) =
-    filterWrapper "declarations" decls
+    filterWrapper "declarations" (map declarationTypeToString decls)
 
 newtype CompletionOptions = CompletionOptions {
   maxResults :: Maybe Int,


### PR DESCRIPTION
This adds support to parse a new ~(not yet agreed-upon or approved)~ field in `TypeInfo` that allows narrowing down import requests to specify the namespace.

See purescript/purescript#3997 