### PR TITLE
Upgrade to 0.15

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -1,6 +1,5 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.15.0-20220505/packages.dhall
-        sha256:ba57c25c86fd54c2b672cda3a6836bbbdff4b1bbf946bceaabb64e5a10285638
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.14-20240227/packages.dhall sha256:c9633eb78193aac138d7debbc907bfedb8f2e3025ef5a874b8dbc1f35b75eef4
 
 let overrides = {=}
 


### PR DESCRIPTION
This is an upgrade to the latest package-set 0.15.14, uses new ChildProcess modules and adds ability to provide `shell` param to exec calls.